### PR TITLE
Update to node24

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
       - name: Install dependencies
         run: npm ci
       - name: Rebuild the dist/ directory

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: '*.json'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
## Summary

- Switch `runs.using` from `node20` to `node24`

## Why

GitHub is deprecating Node 20 on Actions runners and recommends updating actions to Node 24.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/